### PR TITLE
Remove '!!' because .NET 6.0.400 was released and it doesn't support it

### DIFF
--- a/console/currency-converter-lib/currency-converter-lib.csproj
+++ b/console/currency-converter-lib/currency-converter-lib.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/console/currency-converter-lib/exchange-sources/cbr/cbr-adapter.cs
+++ b/console/currency-converter-lib/exchange-sources/cbr/cbr-adapter.cs
@@ -12,8 +12,14 @@ namespace CurrencyConverter.ExchangeRateSources.Cbr {
     private string cbrRatesUrl { get; }
     private HttpClient client { get; }
 
-    public CbrExchangeRatesAdapter(string cbrRatesUrl!!) : this(new HttpClient(), cbrRatesUrl) {}
-    public CbrExchangeRatesAdapter(HttpClient client!!, string cbrRatesUrl!!) {
+    public CbrExchangeRatesAdapter(string cbrRatesUrl) : this(new HttpClient(), cbrRatesUrl) { }
+    public CbrExchangeRatesAdapter(HttpClient client, string cbrRatesUrl) {
+      if (String.IsNullOrEmpty(cbrRatesUrl)) {
+        throw new ArgumentNullException($"'{nameof(cbrRatesUrl)}' cannot be null or empty.", nameof(cbrRatesUrl));
+      }
+      if (client == null) {
+        throw new ArgumentNullException($"'{nameof(client)}' cannot be null or empty.", nameof(client));
+      }
       this.cbrRatesUrl = cbrRatesUrl;
       this.client = client;
     }

--- a/console/currency-converter-lib/exchange-sources/cbr/cbr-rates-source.cs
+++ b/console/currency-converter-lib/exchange-sources/cbr/cbr-rates-source.cs
@@ -35,8 +35,11 @@ namespace CurrencyConverter.ExchangeRateSources.Cbr {
     }
 
     public CbrRatesSource() : this(new CbrExchangeRatesAdapter(new HttpClient(), DefaultCbrRatesUrl)) { }
-    public CbrRatesSource(string cbrRatesUrl!!) : this(new CbrExchangeRatesAdapter(cbrRatesUrl)) { }
-    public CbrRatesSource(ICbrRatesAdapter adapter!!) {
+    public CbrRatesSource(string cbrRatesUrl) : this(new CbrExchangeRatesAdapter(cbrRatesUrl)) { }
+    public CbrRatesSource(ICbrRatesAdapter adapter) {
+      if (adapter == null) {
+        throw new ArgumentNullException($"'{nameof(adapter)}' cannot be null or empty.", nameof(adapter));
+      }
       this.adapter = adapter;
     }
 

--- a/console/currency-converter-lib/exchange-sources/exchange-sources-manager.cs
+++ b/console/currency-converter-lib/exchange-sources/exchange-sources-manager.cs
@@ -13,15 +13,21 @@ namespace CurrencyConverter.ExchangeRateSources {
       this.sources.Clear();
     }
 
-    public void RegisterSource(string sourceName!!, IExchangeRatesSource exchangeSource!!) {
-      if (sourceName == String.Empty) {
+    public void RegisterSource(string sourceName, IExchangeRatesSource exchangeSource) {
+      if (String.IsNullOrEmpty(sourceName)) {
         throw new ArgumentNullException($"'{nameof(sourceName)}' cannot be null or empty.", nameof(sourceName));
+      }
+      if (exchangeSource == null) {
+        throw new ArgumentNullException($"'{nameof(exchangeSource)}' cannot be null or empty.", nameof(exchangeSource));
       }
 
       this.sources.Add(sourceName, exchangeSource);
     }
 
-    public IExchangeRatesSource GetSource(string sourceName!!) {
+    public IExchangeRatesSource GetSource(string sourceName) {
+      if (String.IsNullOrEmpty(sourceName)) {
+        throw new ArgumentNullException($"'{nameof(sourceName)}' cannot be null or empty.", nameof(sourceName));
+      }
       IExchangeRatesSource? exchangeRatesSource;
       if (!sources.TryGetValue(sourceName, out exchangeRatesSource) || (exchangeRatesSource == null)) {
         throw new Exception($"Cannot find '{sourceName}' rates source. Available sources: {String.Join(", ", sources.Keys)}.");

--- a/console/currency-converter-tests/currency-converter-tests.csproj
+++ b/console/currency-converter-tests/currency-converter-tests.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>preview</LangVersion>
     
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/console/currency-converter/currency-converter.csproj
+++ b/console/currency-converter/currency-converter.csproj
@@ -11,7 +11,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The `!!` was compiled successfully with 6.0.302, but compilation fails with 6.0.400 with the `The 'parameter null-checking' feature is not supported.` error